### PR TITLE
Add TinyUSB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: vendor/
+exclude: vendor/.*/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/meson.build
+++ b/meson.build
@@ -15,5 +15,4 @@ objcopy = find_program('arm-none-eabi-objcopy')
 convert_bin_cmd = [objcopy, '-O', 'binary', '@INPUT@',  '@OUTPUT@']
 linker = meson.current_source_dir() + '/' + target_machine.cpu() + '.ld'
 
-inc = include_directories('include')
 subdir('src')

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -27,7 +27,7 @@
 #ifndef FREERTOS_CONFIG_H
 #define FREERTOS_CONFIG_H
 
-#include "system_stm32f4xx.h"
+#include <system_stm32f4xx.h>
 
 /*-----------------------------------------------------------
  * Application specific definitions.

--- a/src/main.c
+++ b/src/main.c
@@ -1,25 +1,76 @@
 #include <FreeRTOS.h>
 #include <stm32f4xx.h>
 #include <task.h>
+#include <tusb.h>
 
-StackType_t blinkLedStack[configMINIMAL_STACK_SIZE];
+#define TINY_USB_TASK_STACK_SIZE 180
+
+StackType_t blinkLedTaskStack[configMINIMAL_STACK_SIZE];
 StaticTask_t blinkLedTaskHandle;
 
+StackType_t tinyUsbTaskStack[TINY_USB_TASK_STACK_SIZE];
+StaticTask_t tinyUsbTaskHandle;
+
 void prvSetupHardware(void) {
-    SystemInit();
+    __disable_irq();
+    FLASH->ACR |= FLASH_ACR_LATENCY_2WS;
+    while ((FLASH->ACR & FLASH_ACR_LATENCY) != FLASH_ACR_LATENCY_2WS) continue;
+
+    RCC->CFGR |=
+        (0x06 << RCC_CFGR_MCO1PRE_Pos) | (0x03 << RCC_CFGR_MCO1_Pos) | (0x04 << RCC_CFGR_PPRE1_Pos);
+
+    RCC->CR |= RCC_CR_HSEON;
+    while ((RCC->CR & RCC_CR_HSERDY) == 0) continue;
+
+    RCC->PLLCFGR = (6 << RCC_PLLCFGR_PLLQ_Pos) | (288 << RCC_PLLCFGR_PLLN_Pos) |
+                   (25 << RCC_PLLCFGR_PLLM_Pos) | (0x01 << RCC_PLLCFGR_PLLP_Pos) |
+                   RCC_PLLCFGR_PLLSRC_HSE;
+    RCC->CR |= RCC_CR_PLLON;
+    while ((RCC->CR & RCC_CR_PLLRDY) == 0) continue;
+
+    RCC->CFGR |= RCC_CFGR_SW_PLL;
+    while ((RCC->CFGR & RCC_CFGR_SWS) == 0) continue;
+
+    SystemCoreClockUpdate();
     SysTick_Config(SystemCoreClock / 1000);
-    NVIC_SetPriorityGrouping(__NVIC_PRIO_BITS);
 
     RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN;
-    GPIOC->MODER = 1 << GPIO_MODER_MODER13_Pos;
+    GPIOC->MODER = 0x01 << GPIO_MODER_MODER13_Pos;
+
+    RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+    GPIOA->MODER |=
+        (0x02 << GPIO_MODER_MODE8_Pos | (0x02 << GPIO_MODER_MODER11_Pos) |
+         (0x02 << GPIO_MODER_MODER12_Pos));
+    GPIOA->OSPEEDR |= (0x02 << GPIO_OSPEEDR_OSPEED11_Pos) | (0x02 << GPIO_OSPEEDR_OSPEED12_Pos);
+    GPIOA->AFR[1] |= (0x0A << GPIO_AFRH_AFSEL11_Pos) | (0x0A << GPIO_AFRH_AFSEL12_Pos);
+
+    RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
+    while ((USB_OTG_FS->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0) continue;
+
+    NVIC_SetPriority(OTG_FS_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY);
+    USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
+    USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBUSBSEN;
+    USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBUSASEN;
+
+    tusb_init();
 }
 
+void OTG_FS_IRQHandler(void) { tud_int_handler(0); }
+
 void blinkLedTask(void *pvParameters) {
+    (void)pvParameters;
     while (1) {
         GPIOC->ODR = 0xFFFFFFFF;
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        vTaskDelay(pdMS_TO_TICKS(1950));
         GPIOC->ODR = 0;
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+}
+
+void tinyUsbTask(void *pvParameters) {
+    while (1) {
+        (void)pvParameters;
+        tud_task();
     }
 }
 
@@ -39,7 +90,7 @@ void vApplicationGetIdleTaskMemory(
 void vApplicationTickHook(void) {}
 void vApplicationIdleHook(void) {}
 
-void main(void) {
+int main(void) {
     prvSetupHardware();
 
     xTaskCreateStatic(
@@ -48,11 +99,22 @@ void main(void) {
         configMINIMAL_STACK_SIZE,
         NULL,
         tskIDLE_PRIORITY,
-        blinkLedStack,
+        blinkLedTaskStack,
         &blinkLedTaskHandle
     );
+    configASSERT(&blinkLedTaskHandle);
+
+    xTaskCreateStatic(
+        tinyUsbTask,
+        "TinyUSB",
+        TINY_USB_TASK_STACK_SIZE,
+        NULL,
+        tskIDLE_PRIORITY + 1,
+        tinyUsbTaskStack,
+        &tinyUsbTaskHandle
+    );
+    configASSERT(&tinyUsbTaskHandle);
 
     vTaskStartScheduler();
-
     while (1) continue;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,7 @@
 main = executable(
   'main',
-  ['main.c', cmsis_f401xc_startup, rtos_core_src, rtos_gcc_arm4f],
-  include_directories: [inc, cmsisf4_inc,  cmsism4_core_inc, rtos_inc, rtos_gcc_armf4_inc],
+  ['main.c', 'usb_descriptors.c', cmsis_f401xc_startup, rtos_core_src, rtos_gcc_arm4f, tusb_src],
+  include_directories: [cmsisf4_inc,  cmsism4_core_inc, rtos_inc, rtos_gcc_armf4_inc, tusb_inc],
   name_suffix: 'elf',
   link_args: ['-T', linker]
  )

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -1,0 +1,99 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _TUSB_CONFIG_H_
+#define _TUSB_CONFIG_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Board Specific Configuration
+//--------------------------------------------------------------------+
+
+#define TUD_OPT_RHPORT 0
+
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+//--------------------------------------------------------------------
+#ifndef CFG_TUSB_MCU
+#error CFG_TUSB_MCU must be defined
+#endif
+
+#define CFG_TUSB_OS OPT_OS_FREERTOS
+
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG 0
+#endif
+
+// Enable Device stack
+#define CFG_TUD_ENABLED 1
+
+// Default is max speed that hardware controller could support with on-chip PHY
+#define CFG_TUD_MAX_SPEED OPT_MODE_FULL_SPEED
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN __attribute__((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
+
+//------------- CLASS -------------//
+#define CFG_TUD_CDC 1
+#define CFG_TUD_MSC 0
+#define CFG_TUD_HID 0
+#define CFG_TUD_MIDI 0
+#define CFG_TUD_VENDOR 0
+
+// CDC FIFO size of TX and RX
+#define CFG_TUD_CDC_RX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#define CFG_TUD_CDC_TX_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+// CDC Endpoint transfer buffer size, more is faster
+#define CFG_TUD_CDC_EP_BUFSIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TUSB_CONFIG_H_ */

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -1,0 +1,101 @@
+#include <tusb.h>
+
+#define USB_PID 0x5740
+#define USB_VID 0x0483
+#define USB_BCD 0x0200
+
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t const desc_device = {
+    .bLength = sizeof(tusb_desc_device_t),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB = USB_BCD,
+    .bDeviceClass = TUSB_CLASS_CDC,
+    .bDeviceSubClass = CDC_COMM_SUBCLASS_ABSTRACT_CONTROL_MODEL,
+    .bDeviceProtocol = CDC_COMM_PROTOCOL_NONE,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .idVendor = USB_VID,
+    .idProduct = USB_PID,
+    .bcdDevice = 0x0100,
+    .iManufacturer = 1,
+    .iProduct = 2,
+    .iSerialNumber = 3,
+    .bNumConfigurations = 1};
+
+uint8_t const* tud_descriptor_device_cb(void) { return (uint8_t const*)&desc_device; }
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + CFG_TUD_CDC * TUD_CDC_DESC_LEN)
+
+#define EPNUM_CDC_0_NOTIF 0x81
+#define EPNUM_CDC_0_OUT 0x02
+#define EPNUM_CDC_0_IN 0x82
+
+uint8_t const desc_fs_configuration[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, 2, 0, CONFIG_TOTAL_LEN, 0x00, 500),
+    // 1st CDC: Interface number, string index, EP notification address and size, EP data address
+    // (out, in) and size.
+    TUD_CDC_DESCRIPTOR(0, 3, EPNUM_CDC_0_NOTIF, 8, EPNUM_CDC_0_OUT, EPNUM_CDC_0_IN, 64),
+};
+
+// Invoked when received GET CONFIGURATION DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const* tud_descriptor_configuration_cb(uint8_t index) {
+    (void)index;  // for multiple configurations
+    return desc_fs_configuration;
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+// array of pointer to string descriptors
+char const* string_desc_arr[] = {
+    (const char[]){0x09, 0x04},  // 0: is supported language is English (0x0409)
+    "Zoftko",                    // 1: Manufacturer
+    "Stell",                     // 2: Product
+    "123456",                    // 3: Serials, should use chip ID
+    "Stell CDC",                 // 4: CDC Interface
+};
+
+static uint16_t _desc_str[32];
+
+// Invoked when received GET STRING DESCRIPTOR request
+// Application return pointer to descriptor, whose contents must exist long enough for transfer to
+// complete
+uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
+    (void)langid;
+
+    uint8_t chr_count;
+
+    if (index == 0) {
+        memcpy(&_desc_str[1], string_desc_arr[0], 2);
+        chr_count = 1;
+    } else {
+        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+        if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0]))) return NULL;
+
+        const char* str = string_desc_arr[index];
+
+        // Cap at max char
+        chr_count = (uint8_t)strlen(str);
+        if (chr_count > 31) chr_count = 31;
+
+        // Convert ASCII string into UTF-16
+        for (uint8_t i = 0; i < chr_count; i++) {
+            _desc_str[1 + i] = str[i];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+    return _desc_str;
+}

--- a/stm32f401xc.ini
+++ b/stm32f401xc.ini
@@ -1,11 +1,12 @@
 [constants]
 define_cpu = 'STM32F401xC'
+define_tusb_mcu = 'OPT_MCU_STM32F4'
 target_cpu = 'stm32f401xc'
 target_cortex = 'cortex-m4'
 
 [built-in options]
 b_staticpic = false
-c_args = ['-mcpu=' + target_cortex, '-D' + define_cpu, '-nostdlib', '-mfloat-abi=hard', '-mthumb', '-DUSE_FULL_LL_DRIVER', '-ffunction-sections', '-fdata-sections']
+c_args = ['-mcpu=' + target_cortex, '-D' + define_cpu, '-DCFG_TUSB_MCU=' + define_tusb_mcu, '-nostdlib', '-mfloat-abi=hard', '-mthumb', '-DUSE_FULL_LL_DRIVER', '-ffunction-sections', '-fdata-sections']
 c_link_args = ['-mcpu=' + target_cortex, '--specs=nosys.specs', '-mfloat-abi=hard', '-Wl,--gc-sections']
 default_library = 'static'
 

--- a/vendor/meson.build
+++ b/vendor/meson.build
@@ -11,4 +11,11 @@ rtos_core_src = files('free-rtos/queue.c', 'free-rtos/tasks.c', 'free-rtos/list.
 rtos_gcc_armf4_inc = include_directories('free-rtos/portable/GCC/ARM_CM4F')
 rtos_gcc_arm4f = files('free-rtos/portable/GCC/ARM_CM4F/port.c')
 
-rtos_heap_4 = files('free-rtos/portable/MemMang/heap_4.c')
+tusb_inc = include_directories(
+'tinyusb/src', 'tinyusb/src/common', 'tinyusb/src/device', 'tinyusb/src/class/cdc',
+'tinyusb/src/portable/synopsys/dwc2', 'tinyusb/src/osal'
+)
+tusb_src = files(
+'tinyusb/src/tusb.c', 'tinyusb/src/portable/synopsys/dwc2/dcd_dwc2.c', 'tinyusb/src/common/tusb_fifo.c',
+'tinyusb/src/device/usbd.c', 'tinyusb/src/device/usbd_control.c', 'tinyusb/src/class/cdc/cdc_device.c'
+)


### PR DESCRIPTION
TinyUSB has been added to support device mode in CDC. It has been configured to run with FreeRTOS. No RX/TX is being performed as of now. Only device enumeration is handled.